### PR TITLE
Refactor 3

### DIFF
--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -9,8 +9,6 @@ const orgRepositoriesNameSelector = 'a[data-hovercard-type=repository]';
 const orgName = 'Indigov';
 const expectedTotalRepos = '17';
 const expectedTsRepos = '5';
-var repoNames = [];
-var sortedRepoNames = [];
 
 describe('Github Landing Page and Total Repos', () => {
   it('should visit Indigov landing page', () => {
@@ -36,30 +34,37 @@ describe('Sort and Filter Repos', () => {
   });
   
   it('sorts the TS repos by name, descending', () => {
-    //Have to wait for list to re-render after sort.  Cypress does this implicitly on 
-    //a new page redirect, but not for this type of click.  The list is available 
-    //in the DOM the entire time, so waiting on elements to be available also does not work.
-    cy.wait(500);  
- 
-    cy.get('@repoList').find(orgRepositoriesNameSelector).each((a) => {
-      repoNames.push(a.text().trim());
-      sortedRepoNames.push(a.text().trim());
-    }).then( () => {
+    let repoNames = [];
+    let sortedRepoNames = [];
+
+    cy.get('@repoList').find(orgRepositoriesNameSelector).should((a) => {
+      let repoName = a.text().trim();
+      repoNames.map((repoName) => repoName);
+      sortedRepoNames.map((repoName) => repoName);
+
       expect(repoNames).to.deep.equal(sortedRepoNames.sort());
     });
   });
 
   it('shows the correct clone link for the last sorted repo', () => {
-    //Have to wait for list to re-render after sort.  Cypress does this implicitly on 
-    //a new page redirect, but not for this type of click.  The list is available 
-    //in the DOM the entire time, so waiting on elements to be available also does not work.
-    cy.wait(500);
-    cy.get('@repoList').find(orgRepositoriesNameSelector).last().as('lastRepo')
-      .then($lastRepo => {
-        //Store the name of the last repo for link verification before clicking on it
-      const lastRepoName = $lastRepo.text().trim();
-      cy.wrap(lastRepoName).as('lastRepoName');
+    //Ensure repos are sorted before getting last one
+    let repoNames = [];
+    let sortedRepoNames = [];
+
+    cy.get('@repoList').find(orgRepositoriesNameSelector).should((a) => {
+      let repoName = a.text().trim();
+      repoNames.map((repoName) => repoName);
+      sortedRepoNames.map((repoName) => repoName);
+
+      expect(repoNames).to.deep.equal(sortedRepoNames.sort());
     });
+
+    cy.get('@repoList').find(orgRepositoriesNameSelector).last().as('lastRepo')
+      .then(lastRepo => {
+        //Store the name of the last repo for link verification before clicking on it
+        const lastRepoName = lastRepo.text().trim();
+        cy.wrap(lastRepoName).as('lastRepoName');
+      });
 
     cy.get('@lastRepo').click();
     cy.get('get-repo').click();

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -39,8 +39,8 @@ describe('Sort and Filter Repos', () => {
 
     cy.get('@repoList').find(orgRepositoriesNameSelector).should((a) => {
       let repoName = a.text().trim();
-      repoNames.map((repoName) => repoName);
-      sortedRepoNames.map((repoName) => repoName);
+      repoNames.push(repoName);
+      sortedRepoNames.push(repoName);
 
       expect(repoNames).to.deep.equal(sortedRepoNames.sort());
     });
@@ -53,8 +53,8 @@ describe('Sort and Filter Repos', () => {
 
     cy.get('@repoList').find(orgRepositoriesNameSelector).should((a) => {
       let repoName = a.text().trim();
-      repoNames.map((repoName) => repoName);
-      sortedRepoNames.map((repoName) => repoName);
+      repoNames.push(repoName);
+      sortedRepoNames.push(repoName);
 
       expect(repoNames).to.deep.equal(sortedRepoNames.sort());
     });

--- a/testing-notes.md
+++ b/testing-notes.md
@@ -16,3 +16,8 @@ work with developers to add permanent testing IDs to the elements used for autom
 There are a few places where I reuse code that could be placed into separate functions.  
 For this small project, this works fine, but for more tests I would export common functions 
 (like getting lists and ensuring they're sorted) for better maintainability.
+
+# App Response Flakiness
+I occasionally run into an error from the Github app itself, not my tests, that interrupts 
+my beforeEach block for sorting repos.  After trying a few approaches, this seems to have little to do with specific features of my tests, and they often pass on a retry.  This is 
+hard to diagnose and further debug without access to the app itself and related logs.

--- a/testing-notes.md
+++ b/testing-notes.md
@@ -12,9 +12,7 @@ use them; otherwise, I had to rely on other permanent tags or attributes combine
 nesting of element get/find.  If this were an application I wanted to test further, I would 
 work with developers to add permanent testing IDs to the elements used for automated tests.
 
-# beforeEach and Sorting
-For the second block of tests, I would have liked to move the sort-by-name functionality 
-up to the beforeEach hook.  It's used by two of the three tests in the block and won't 
-interfere with the third.  However, doing so kept tripping an unhandled promise error 
-from the application itself, causing Cypress to skip and fail the rest of the tests. This error was not visible in the browser console, so I would need access to the 
-application and its logs to properly debug this issue.
+# Modular Refactor of Reusable Functions
+There are a few places where I reuse code that could be placed into separate functions.  
+For this small project, this works fine, but for more tests I would export common functions 
+(like getting lists and ensuring they're sorted) for better maintainability.


### PR DESCRIPTION
This PR makes refactoring improvements to the spec.cy.js file.  Most notably, waits are no longer needed thanks to the introduction of sorting assertion in a `should` callback.